### PR TITLE
Missing <limits> include

### DIFF
--- a/players/common/searchingAlgorithms/MinMax.cpp
+++ b/players/common/searchingAlgorithms/MinMax.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include "MinMax.hpp"
 
 


### PR DESCRIPTION
Not sure why, but with my setup project doesn't compile due to missing `#include <limits>` in MinMax.cpp.

GCC: 10.2.0
cmake: 3.19.2

Here is what I do:

```shell
git clone https://github.com/PiotrWi/chess
cd chess
mkdir build
cd build
cmake ..
make
```

Error:

```plain
[ 28%] Building CXX object players/CMakeFiles/Players.dir/common/searchingAlgorithms/MinMax.cpp.o
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp: In function ‘int {anonymous}::evaluateMin(BoardEngine&, unsigned char, NOTATION::COLOR::color)’:
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:22:21: error: ‘numeric_limits’ is not a member of ‘std’
   22 |         return std::numeric_limits<int>::max();
      |                     ^~~~~~~~~~~~~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:22:36: error: expected primary-expression before ‘int’
   22 |         return std::numeric_limits<int>::max();
      |                                    ^~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:22:36: error: expected ‘;’ before ‘int’
   22 |         return std::numeric_limits<int>::max();
      |                                    ^~~
      |                                    ;
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:22:39: error: expected unqualified-id before ‘ ’ token
   22 |         return std::numeric_limits<int>::max();
      |                                       ^
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:29:31: error: ‘numeric_limits’ is not a member of ‘std’
   29 |     auto greatestValue = std::numeric_limits<int>::max();
      |                               ^~~~~~~~~~~~~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:29:46: error: expected primary-expression before ‘int’
   29 |     auto greatestValue = std::numeric_limits<int>::max();
      |                                              ^~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp: In function ‘int {anonymous}::evaluateMax(BoardEngine&, unsigned char, NOTATION::COLOR::color)’:
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:55:21: error: ‘numeric_limits’ is not a member of ‘std’
   55 |         return std::numeric_limits<int>::min();
      |                     ^~~~~~~~~~~~~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:55:36: error: expected primary-expression before ‘int’
   55 |         return std::numeric_limits<int>::min();
      |                                    ^~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:55:36: error: expected ‘;’ before ‘int’
   55 |         return std::numeric_limits<int>::min();
      |                                    ^~~
      |                                    ;
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:55:39: error: expected unqualified-id before ‘ ’ token
   55 |         return std::numeric_limits<int>::min();
      |                                       ^
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:62:31: error: ‘numeric_limits’ is not a member of ‘std’
   62 |     auto greatestValue = std::numeric_limits<int>::min();
      |                               ^~~~~~~~~~~~~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:62:46: error: expected primary-expression before ‘int’
   62 |     auto greatestValue = std::numeric_limits<int>::min();
      |                                              ^~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp: In function ‘Move minMax::evaluate(BoardEngine, unsigned char)’:
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:87:31: error: ‘numeric_limits’ is not a member of ‘std’
   87 |     auto greatestValue = std::numeric_limits<int>::min();
      |                               ^~~~~~~~~~~~~~
/home/work/dev/piotrchess/chess/players/common/searchingAlgorithms/MinMax.cpp:87:46: error: expected primary-expression before ‘int’
   87 |     auto greatestValue = std::numeric_limits<int>::min();
      |                                              ^~~
make[2]: *** [players/CMakeFiles/Players.dir/build.make:108: players/CMakeFiles/Players.dir/common/searchingAlgorithms/MinMax.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:274: players/CMakeFiles/Players.dir/all] Error 2
make: *** [Makefile:103: all] Error 2
```